### PR TITLE
OCSADV-517: Fixed issues with empty manual guide groups and editor not being changed.

### DIFF
--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/TargetSelection.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/target/obsComp/TargetSelection.java
@@ -175,10 +175,13 @@ public final class TargetSelection {
         return Selection.toSelections(env).find(sel -> sel.getTarget().exists(target::equals)).map(sel -> sel.index);
     }
 
-    public static Option<Integer> indexOfGuideGroup(final TargetEnvironment env,
-                                                    final GuideGroup guideGroup) {
+    /**
+     * Given an index of a guide group in the list of all guide groups, find the corresponding node index.
+     */
+    public static Option<Integer> indexOfGuideGroupByIndex(final TargetEnvironment env,
+                                                           final int guideGroupIndex) {
         final ImList<GuideGroupSelection> selections = GuideGroupSelection.toGuideGroupSelections(env);
-        return selections.find(ggs -> ggs.getGuideGroup().exists(guideGroup::equals)).map(GuideGroupSelection::getIndex);
+        return selections.getOption(guideGroupIndex).map(GuideGroupSelection::getIndex);
     }
 
     private static Option<Selection> selectionAtIndex(final TargetEnvironment env, final int index) {
@@ -210,14 +213,14 @@ public final class TargetSelection {
         // Look for the entry numbered idx in the selections, and if it exists, return it as an IndexedGuideGroup
         // with its index amongst all guide groups.
         return selections.zipWithIndex().find(tup -> tup._1().getIndex() == idx)
-                .map(tup -> IndexedGuideGroup$.MODULE$.apply(tup._2(), tup._1().guideGroup));
+                .map(tup -> new IndexedGuideGroup(tup._2(), tup._1().guideGroup));
     }
 
     /**
      * For a given guide group, find the corresponding node in the list if it exists, and set it as the index.
      */
-    public static void setGuideGroup(final TargetEnvironment env, final ISPNode node, final GuideGroup gg) {
-        setIndex(node, indexOfGuideGroup(env, gg));
+    public static void setGuideGroupByIndex(final TargetEnvironment env, final ISPNode node, final int index) {
+        setIndex(node, indexOfGuideGroupByIndex(env, index));
     }
 
     public static void listenTo(final ISPNode node, final PropertyChangeListener listener) {

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
@@ -768,6 +768,7 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
         @Override public void actionPerformed(final ActionEvent e) {
             // As long as something is selected, we can paste it.
             _curSelection.foreach(ignored -> pasteSelectedPosition(getNode(), getDataObject()));
+            _curSelection.swap().foreach(ignored -> pasteSelectedPosition(getNode(), getDataObject()));
         }
     };
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
@@ -222,11 +222,12 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
         final boolean notBase       = !selectionIsBasePosition();
         final boolean notAutoTarget = !selectionIsAutoTarget();
         final boolean isGuideStar   = selectionIsGuideTarget();
+        final boolean isUserTarget  = selectionIsUserTarget();
 
         _w.removeButton.setEnabled (editable && notBase && notAutoTarget);
         _w.primaryButton.setEnabled(editable && isGuideStar && notAutoTarget);
         _w.pasteButton.setEnabled(editable && notAutoTarget);
-        _w.duplicateButton.setEnabled(editable && isGuideStar && notAutoTarget);
+        _w.duplicateButton.setEnabled(editable && ((isGuideStar && notAutoTarget) || isUserTarget));
         updateDetailEditorEnabledState(editable && notAutoTarget);
     }
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/EdCompTargetList.java
@@ -222,12 +222,11 @@ public final class EdCompTargetList extends OtItemEditor<ISPObsComponent, Target
         final boolean notBase       = !selectionIsBasePosition();
         final boolean notAutoTarget = !selectionIsAutoTarget();
         final boolean isGuideStar   = selectionIsGuideTarget();
-        final boolean isUserTarget  = selectionIsUserTarget();
 
         _w.removeButton.setEnabled (editable && notBase && notAutoTarget);
         _w.primaryButton.setEnabled(editable && isGuideStar && notAutoTarget);
         _w.pasteButton.setEnabled(editable && notAutoTarget);
-        _w.duplicateButton.setEnabled(editable && ((isGuideStar && notAutoTarget) || isUserTarget));
+        _w.duplicateButton.setEnabled(editable && notAutoTarget);
         updateDetailEditorEnabledState(editable && notAutoTarget);
     }
 

--- a/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
+++ b/bundle/jsky.app.ot/src/main/java/jsky/app/ot/gemini/editor/targetComponent/TelescopePosTableWidget.java
@@ -640,7 +640,7 @@ public final class TelescopePosTableWidget extends JTable implements TelescopePo
                 startWatchingSelection();
             }
         });
-        row.group().foreach(igg -> TargetSelection.setGuideGroup(_env, _obsComp, igg.group()));
+        row.group().foreach(igg -> TargetSelection.setGuideGroupByIndex(_env, _obsComp, igg.index()));
     }
 
     private final PropertyChangeListener selectionListener = evt -> {
@@ -887,7 +887,7 @@ public final class TelescopePosTableWidget extends JTable implements TelescopePo
      * Update the TargetSelection's group, and sets the relevant row in the table.
      */
     void selectGroup(final IndexedGuideGroup igg) {
-        TargetSelection.setGuideGroup(_env, _obsComp, igg.group());
+        TargetSelection.setGuideGroupByIndex(_env, _obsComp, igg.index());
         _tableData.rowIndexForGroupIndex(igg.index()).foreach(this::_setSelectedRow);
     }
 


### PR DESCRIPTION
This fairly small PR fixes the three key issues we identified yesterday for the UI:
1. When a target was deleted, the editor pane was not properly updated to reflect the new selection.
2. When two empty manual guide groups were present:
2a. trying to update the name of the second updated the name of the first; and
2b. trying to add a guide star to the second actually added a guide star to the first.

(1) was due to an oversight in not updating the new selection properly. Since this needs to be done in two cases (during deletions and during selection changes), I have refactored the code for this out into a new method that is used in both instances, namely `EdCompTargetList.setSelectionFromNode`.

(2) was due to empty manual groups being considered equal, so when looking for the index of an empty manual group in the list of all groups, the index of the first empty manual group was returned. This is solved by changing methods of TargetSelection to use indices of groups (amongst all groups) to convert to indices of nodes.
